### PR TITLE
Fix mapping examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,27 @@ The answer is to include a level (like this: `"{{{1`), but I'm too lazy for that
     au BufRead,BufNewFile *.vim let b:chalk_space_before = 1
 
 
-    vmap zf <Plug>Chalk          " Create fold at visual selection
-    nmap zf <Plug>Chalk          " Create fold at operator movement
-    nmap zF <Plug>ChalkRange     " Create fold for specified number of lines
+    " Create fold at visual selection
+    vmap zf <Plug>Chalk
+    " Create fold at operator movement
+    nmap zf <Plug>Chalk
+    " Create fold for specified number of lines
+    nmap zF <Plug>ChalkRange
 
-    nmap Zf <Plug>SingleChalk    " Create single (opening) fold marker
-                                 " at current level or specified count
-    nmap ZF <Plug>SingleChalkUp  " Create single (opening) fold marker
-                                 "  at next levelor specified count
+    " Create single (opening) fold marker at current level or specified count
+    nmap Zf <Plug>SingleChalk
+    " Create single (opening) fold marker at next levelor specified count
+    nmap ZF <Plug>SingleChalkUp
 
-    nmap =z <Plug>ChalkUp        " Increment current fold level
-    nmap -z <Plug>ChalkDown      " Decrement current fold level
-    vmap =z <Plug>ChalkUp        " Increment levels in selection
-    vmap -z <Plug>ChalkDown      " Decrement levels in selection
+
+    " Increment current fold level
+    nmap =z <Plug>ChalkUp
+    " Decrement current fold level
+    nmap -z <Plug>ChalkDown
+    " Increment levels in selection
+    vmap =z <Plug>ChalkUp
+    " Decrement levels in selection
+    vmap -z <Plug>ChalkDown
     ```
 
     (Choose the mappings you prefer. These are only suggestions.)

--- a/doc/chalk.txt
+++ b/doc/chalk.txt
@@ -40,20 +40,27 @@ corresponding directory under `~/.vim/`.
 >
     set foldmethod=marker
 
-    vmap zf <Plug>Chalk          " Create fold at visual selection
-    nmap zf <Plug>Chalk          " Create fold at operator movement
-    nmap zF <Plug>ChalkRange     " Create fold for specified number of lines
+    " Create fold at visual selection
+    vmap zf <Plug>Chalk
+    " Create fold at operator movement
+    nmap zf <Plug>Chalk
+    " Create fold for specified number of lines
+    nmap zF <Plug>ChalkRange
 
-    nmap Zf <Plug>SingleChalk    " Open single fold at current level
-                                 " or specified count
-    nmap ZF <Plug>SingleChalkUp  " Open single fold at next level
-                                 " or specified count
+    " Create single (opening) fold marker at current level or specified count
+    nmap Zf <Plug>SingleChalk
+    " Create single (opening) fold marker at next levelor specified count
+    nmap ZF <Plug>SingleChalkUp
 
-    nmap =z <Plug>ChalkUp        " Increment current fold level
-    nmap -z <Plug>ChalkDown      " Decrement current fold level
-    vmap =z <Plug>ChalkUp        " Increment levels in selection
-    vmap -z <Plug>ChalkDown      " Decrement levels in selection
-<
+
+    " Increment current fold level
+    nmap =z <Plug>ChalkUp
+    " Decrement current fold level
+    nmap -z <Plug>ChalkDown
+    " Increment levels in selection
+    vmap =z <Plug>ChalkUp
+    " Decrement levels in selection
+    vmap -z <Plug>ChalkDown
 
 (Chose the mappings you prefer. These are only suggestions.)
 


### PR DESCRIPTION
See :help map-comments

It is not possible to put a comment after these commands, because the
`"` character is considered to be part of the {lhs} or {rhs}.